### PR TITLE
Prune expired sessions.

### DIFF
--- a/src/prune-sessions.js
+++ b/src/prune-sessions.js
@@ -1,0 +1,7 @@
+import Session from './session.js';
+
+const sessions = Session.all;
+console.log(sessions);
+Session.prune(sessions);
+console.log(sessions);
+Session.all = sessions;

--- a/src/session.js
+++ b/src/session.js
@@ -56,4 +56,15 @@ export default class Session {
     static generate() {
         return crypto.randomBytes(16).toString('base64');
     }
+
+    static prune(sessions) {
+        for (const sessionID in sessions) {
+            const session = sessions[sessionID];
+            if (session.expires <= Date.now()) {
+                delete sessions[sessionID];
+                const expires = new Date(session.expires);
+                console.log(`Deleted ${session.name}'s session ID '${sessionID}' that expired at ${expires.toISOString()}.`);
+            }
+        }
+    }
 }

--- a/tests/session.js
+++ b/tests/session.js
@@ -27,4 +27,28 @@ tests['Session ID meets requirements.'] = () => {
     return failures;
 };
 
+tests['Expired sessions get pruned.'] = () => {
+    let failures = [];
+    let count = -2;
+    const now = Date.now();
+    const sessions = {};
+    while (count++ < 0) {
+        const sessionID = Session.generate();
+        sessions[sessionID] = {
+            name: 'ryan',
+            expires: now - (count * 86400000),
+        };
+    }
+    //console.log(sessions);
+    Session.prune(sessions);
+    //console.log(sessions);
+    for (const sessionID in sessions) {
+        const session = sessions[sessionID];
+        if (session.expires <= now) {
+            failures.push(`Did not prune session that expired ${now - session.expires} seconds before the cutoff.`);
+        }
+    }
+    return failures;
+};
+
 export default tests;


### PR DESCRIPTION
A session expires, but previously we only deleted that session from server storage when requested after expiration time. Now we loop through all the sessions in storage and prune those that are expired.

I've chosen to keep pruning a manual operation for the server admin, by running:

    cd src/
    node prune-sessions.js

I considered running Session.prune automatically from Session.delete(), but I don't want UX to suffer as the number of sessions increases.